### PR TITLE
Preserve

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,23 @@
+# Drupal editor configuration normalization
+# @see http://editorconfig.org/
+
+# This is the top-most .editorconfig file; do not search in parent directories.
+root = true
+
+# All files.
+[*]
+end_of_line = LF
+indent_style = space
+indent_size = 2
+charset = utf-8
+trim_trailing_whitespace = true
+insert_final_newline = true
+
+[*.twig]
+max_line_length = 120
+
+[*.md]
+max_line_length = 80
+
+[composer.json]
+indent_size = 4

--- a/README.md
+++ b/README.md
@@ -1,8 +1,9 @@
 # OSU Editorial Workflow Module
 
-The OSU Editorial Workflow module is designed to ensure that all required modules for an effective editorial workflow
-are installed and necessary permissions are assigned. This module simplifies the process of setting up a comprehensive
-editorial workflow in your Drupal site.
+The OSU Editorial Workflow module is designed to ensure that all required
+modules for an effective editorial workflow are installed and necessary
+permissions are assigned. This module simplifies the process of setting up a
+comprehensive editorial workflow in your Drupal site.
 
 ## Features
 
@@ -16,20 +17,23 @@ editorial workflow in your Drupal site.
 ## Installation
 
 1. **Download the module**: You can download the OSU Editorial Workflow module
-   from [Drupal.org](https://www.drupal.org/project/osu_editorial_workflow) or using Composer:
+   from [Drupal.org](https://www.drupal.org/project/osu_editorial_workflow) or
+   using Composer:
     ```bash
     composer require drupal/osu_editorial_workflow
     ```
 
-2. **Enable the module**: Enable the module using Drush or via the Drupal admin interface:
+2. **Enable the module**: Enable the module using Drush or via the Drupal admin
+   interface:
     ```bash
     drush en osu_editorial_workflow -y
     ```
 
 ## Configuration
 
-After enabling the module, all required sub-modules will be enabled, and permissions will be automatically set. You can
-review and adjust these settings if necessary in the Drupal admin interface.
+After enabling the module, all required sub-modules will be enabled, and
+permissions will be automatically set. You can review and adjust these settings
+if necessary in the Drupal admin interface.
 
 ## Maintainers
 
@@ -37,4 +41,5 @@ review and adjust these settings if necessary in the Drupal admin interface.
 
 ## License
 
-This project is licensed under the GNU General Public License, version 2 or later.
+This project is licensed under the GNU General Public License, version 2 or
+later.

--- a/composer.json
+++ b/composer.json
@@ -17,8 +17,8 @@
     "yaml-lint": "yaml-lint *.yml"
   },
   "require-dev": {
-    "dealerdirect/phpcodesniffer-composer-installer": "^1.0",
-    "squizlabs/php_codesniffer": "^3.11",
+    "dealerdirect/phpcodesniffer-composer-installer": "^1.2",
+    "squizlabs/php_codesniffer": "^3.13",
     "drupal/coder": "^8.3"
   },
   "config": {

--- a/modules/osu_a11y_remediation/README.md
+++ b/modules/osu_a11y_remediation/README.md
@@ -1,0 +1,39 @@
+# OSU Remediation Module
+
+This module provides a workflow for accessibility remediation requests.
+
+## Installation
+
+1. Enable the module via the UI or config.
+2. Run database updates:
+   drush updatedb
+3. Every existing node type will have a new field added to it.
+   This field is not rendered normally and will be used as part of our Preserve
+   workflow.
+
+## Removal
+
+When this feature is no longer needed, removal must follow this exact sequence
+to avoid data loss or schema conflicts:
+
+### Before uninstalling
+
+1. Export any accessibility remediation email data you need to retain.
+2. Confirm with stakeholders that all sites have addressed outstanding
+   remediation requests.
+
+### Removal steps
+
+1. Remove the Preserve—Public Record Exception workflow state and transition
+   from your workflow configuration in the Drupal UI or config.
+2. Uninstall this module:
+   drush pmu osu_a11y_remediation
+   This will automatically remove the field storage and all associated data
+   via hook_uninstall().
+3. Remove the module files from the codebase.
+4. Export and commit config.
+
+### Do not
+
+- Delete the field through the UI (it will not remove the base field storage)
+- Remove the module files before uninstalling (hook_uninstall will not run)

--- a/modules/osu_a11y_remediation/README.md
+++ b/modules/osu_a11y_remediation/README.md
@@ -1,6 +1,10 @@
 # OSU Remediation Module
 
 This module provides a workflow for accessibility remediation requests.
+A new state is added to the Editorial workflow,
+Preserve—Public Record Exposed; Substitute Provided Upon Remediation Request—and
+a new transition is added to the workflow. This is only required on sites
+created before April 24, 2026.
 
 ## Installation
 

--- a/modules/osu_a11y_remediation/config/install/block.block.madrone_views_block__preserve_contact_block_1.yml
+++ b/modules/osu_a11y_remediation/config/install/block.block.madrone_views_block__preserve_contact_block_1.yml
@@ -1,0 +1,35 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - views.view.preserve_contact
+  module:
+    - block_visibility_groups
+    - system
+    - views
+  theme:
+    - madrone
+id: madrone_views_block__preserve_contact_block_1
+theme: madrone
+region: content
+weight: -2
+provider: null
+plugin: 'views_block:preserve_contact-block_1'
+settings:
+  id: 'views_block:preserve_contact-block_1'
+  label: ''
+  label_display: '0'
+  provider: views
+  context_mapping: {  }
+  views_label: ''
+  items_per_page: '1'
+  exposed: {  }
+visibility:
+  condition_group:
+    id: condition_group
+    negate: false
+    block_visibility_group: ''
+  request_path:
+    id: request_path
+    negate: false
+    pages: '/archive/*'

--- a/modules/osu_a11y_remediation/config/install/views.view.preserve_contact.yml
+++ b/modules/osu_a11y_remediation/config/install/views.view.preserve_contact.yml
@@ -1,0 +1,321 @@
+langcode: en
+status: true
+dependencies:
+  module:
+    - node
+    - user
+id: preserve_contact
+label: 'Preserve Contact'
+module: views
+description: ''
+tag: ''
+base_table: node_field_data
+base_field: nid
+display:
+  default:
+    id: default
+    display_title: Default
+    display_plugin: default
+    position: 0
+    display_options:
+      title: 'Preserve Contact'
+      fields:
+        osu_a11y_remediation_email:
+          id: osu_a11y_remediation_email
+          table: node_field_data
+          field: osu_a11y_remediation_email
+          relationship: none
+          group_type: group
+          admin_label: ''
+          entity_type: node
+          entity_field: osu_a11y_remediation_email
+          plugin_id: field
+          label: ''
+          exclude: true
+          alter:
+            alter_text: false
+            text: ''
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: false
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          click_sort_column: value
+          type: email_mailto
+          settings: {  }
+          group_column: value
+          group_columns: {  }
+          group_rows: true
+          delta_limit: 0
+          delta_offset: 0
+          delta_reversed: false
+          delta_first_last: false
+          multi_type: separator
+          separator: ', '
+          field_api_classes: false
+        nothing_1:
+          id: nothing_1
+          table: views
+          field: nothing
+          relationship: none
+          group_type: group
+          admin_label: ''
+          plugin_id: custom
+          label: ''
+          exclude: false
+          alter:
+            alter_text: true
+            text: 'This is archived content.'
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: h2
+          element_class: px-4
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: false
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: false
+        nothing:
+          id: nothing
+          table: views
+          field: nothing
+          relationship: none
+          group_type: group
+          admin_label: ''
+          plugin_id: custom
+          label: ''
+          exclude: false
+          alter:
+            alter_text: true
+            text: 'To request accessibility remediation for this content, please contact: {{ osu_a11y_remediation_email }}'
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: p
+          element_class: p-4
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: false
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: false
+      pager:
+        type: some
+        options:
+          offset: 0
+          items_per_page: 1
+      exposed_form:
+        type: basic
+        options:
+          submit_button: Apply
+          reset_button: false
+          reset_button_label: Reset
+          exposed_sorts_label: 'Sort by'
+          expose_sort_order: true
+          sort_asc_label: Asc
+          sort_desc_label: Desc
+      access:
+        type: perm
+        options:
+          perm: 'access content'
+      cache:
+        type: tag
+        options: {  }
+      empty: {  }
+      sorts:
+        created:
+          id: created
+          table: node_field_data
+          field: created
+          relationship: none
+          group_type: group
+          admin_label: ''
+          entity_type: node
+          entity_field: created
+          plugin_id: date
+          order: DESC
+          expose:
+            label: ''
+            field_identifier: ''
+          exposed: false
+          granularity: second
+      arguments:
+        nid:
+          id: nid
+          table: node_field_data
+          field: nid
+          relationship: none
+          group_type: group
+          admin_label: ''
+          entity_type: node
+          entity_field: nid
+          plugin_id: node_nid
+          default_action: default
+          exception:
+            value: all
+            title_enable: false
+            title: All
+          title_enable: false
+          title: ''
+          default_argument_type: node
+          default_argument_options: {  }
+          summary_options:
+            base_path: ''
+            count: true
+            override: false
+            items_per_page: 25
+          summary:
+            sort_order: asc
+            number_of_records: 0
+            format: default_summary
+          specify_validation: false
+          validate:
+            type: none
+            fail: 'not found'
+          validate_options: {  }
+          break_phrase: false
+          not: false
+      filters:
+        status:
+          id: status
+          table: node_field_data
+          field: status
+          entity_type: node
+          entity_field: status
+          plugin_id: boolean
+          value: '1'
+          group: 1
+          expose:
+            operator: ''
+      style:
+        type: default
+        options:
+          grouping: {  }
+          row_class: 'bg-warning-subtle osu-shadow py-4 rounded-3'
+          default_row_class: true
+      row:
+        type: fields
+      query:
+        type: views_query
+        options:
+          query_comment: ''
+          disable_sql_rewrite: false
+          distinct: false
+          replica: false
+          query_tags: {  }
+      relationships: {  }
+      css_class: 'container py-2'
+      header: {  }
+      footer: {  }
+      display_extenders: {  }
+    cache_metadata:
+      max-age: -1
+      contexts:
+        - 'languages:language_content'
+        - 'languages:language_interface'
+        - url
+        - 'user.node_grants:view'
+        - user.permissions
+      tags: {  }
+  block_1:
+    id: block_1
+    display_title: Block
+    display_plugin: block
+    position: 1
+    display_options:
+      display_extenders:
+        metatag_display_extender:
+          metatags: {  }
+          tokenize: false
+    cache_metadata:
+      max-age: -1
+      contexts:
+        - 'languages:language_content'
+        - 'languages:language_interface'
+        - url
+        - 'user.node_grants:view'
+        - user.permissions
+      tags: {  }

--- a/modules/osu_a11y_remediation/config/install/views.view.preserve_contact.yml
+++ b/modules/osu_a11y_remediation/config/install/views.view.preserve_contact.yml
@@ -319,4 +319,3 @@ display:
         - 'user.node_grants:view'
         - user.permissions
       tags: {  }
-

--- a/modules/osu_a11y_remediation/config/install/views.view.preserve_contact.yml
+++ b/modules/osu_a11y_remediation/config/install/views.view.preserve_contact.yml
@@ -122,7 +122,7 @@ display:
             preserve_tags: ''
             html: false
           element_type: h2
-          element_class: px-4
+          element_class: ''
           element_label_type: ''
           element_label_class: ''
           element_label_colon: false
@@ -145,7 +145,7 @@ display:
           exclude: false
           alter:
             alter_text: true
-            text: 'To request accessibility remediation for this content, please contact: {{ osu_a11y_remediation_email }}'
+            text: 'This content has been archived in accordance with university accessibility policy, procedures and standards. This page is kept for record‑keeping and isn’t actively maintained, so it may not meet current accessibility standards. If you need an accessible version, please send your request to: {{ osu_a11y_remediation_email }}'
             make_link: false
             path: ''
             absolute: false
@@ -171,7 +171,7 @@ display:
             preserve_tags: ''
             html: false
           element_type: p
-          element_class: p-4
+          element_class: ''
           element_label_type: ''
           element_label_class: ''
           element_label_colon: false
@@ -274,7 +274,7 @@ display:
         type: default
         options:
           grouping: {  }
-          row_class: 'bg-warning-subtle osu-shadow py-4 rounded-3'
+          row_class: 'bg-warning-subtle osu-shadow px-3 py-2 rounded-3'
           default_row_class: true
       row:
         type: fields
@@ -319,3 +319,4 @@ display:
         - 'user.node_grants:view'
         - user.permissions
       tags: {  }
+

--- a/modules/osu_a11y_remediation/osu_a11y_remediation.info.yml
+++ b/modules/osu_a11y_remediation/osu_a11y_remediation.info.yml
@@ -1,0 +1,10 @@
+name: OSU Accessibility Remediation
+type: module
+description: Adds accessibility remediation email field to all node types for the Preserve—Public Record Exception workflow state.
+package: OSU
+version: 1.0.3
+core_version_requirement: ^10 || ^11
+dependencies:
+  - osu_editorial_workflow:osu_editorial_workflow
+  - drupal:content_moderation
+  - drupal:node

--- a/modules/osu_a11y_remediation/osu_a11y_remediation.install
+++ b/modules/osu_a11y_remediation/osu_a11y_remediation.install
@@ -5,6 +5,8 @@
  * Installs the accessibility remediation email field.
  */
 
+use Drupal\user\Entity\Role;
+
 /**
  * Implements hook_install().
  */
@@ -16,6 +18,7 @@ function osu_a11y_remediation_install(): void {
     ->loadMultiple();
   _osu_a11y_remediation_setup_workflow($node_types);
   _osu_a11y_add_field_to_node_type($node_types);
+  _osu_a11y_grant_permissions();
 }
 
 /**
@@ -89,5 +92,20 @@ function _osu_a11y_add_field_to_node_type(array $node_types): void {
     $display_repository->getViewDisplay('node', $bundle_id)
       ->removeComponent('osu_a11y_remediation_email')
       ->save();
+  }
+}
+
+/**
+ * Grant Permissions to use the new transition/state.
+ */
+function _osu_a11y_grant_permissions(): void {
+  $roles = [
+    'manage_content',
+    'content_authors',
+    'group_content_author',
+  ];
+  foreach (Role::loadMultiple($roles) as $role) {
+    $role->grantPermission('use editorial transition preserve');
+    $role->save();
   }
 }

--- a/modules/osu_a11y_remediation/osu_a11y_remediation.install
+++ b/modules/osu_a11y_remediation/osu_a11y_remediation.install
@@ -36,13 +36,13 @@ function osu_a11y_remediation_install(): void {
 /**
  * Implements hook_uninstall().
  */
-//function osu_a11y_remediation_uninstall(): void {
-//  $definition_update_manager = \Drupal::entityDefinitionUpdateManager();
-//  $field = $definition_update_manager->getFieldStorageDefinition(
-//    'osu_a11y_remediation_email',
-//    'node'
-//  );
-//  if ($field) {
-//    $definition_update_manager->uninstallFieldStorageDefinition($field);
-//  }
-//}
+function osu_a11y_remediation_uninstall(): void {
+  $definition_update_manager = \Drupal::entityDefinitionUpdateManager();
+  $field = $definition_update_manager->getFieldStorageDefinition(
+    'osu_a11y_remediation_email',
+    'node'
+  );
+  if ($field) {
+    $definition_update_manager->uninstallFieldStorageDefinition($field);
+  }
+}

--- a/modules/osu_a11y_remediation/osu_a11y_remediation.install
+++ b/modules/osu_a11y_remediation/osu_a11y_remediation.install
@@ -9,24 +9,68 @@
  * Implements hook_install().
  */
 function osu_a11y_remediation_install(): void {
+  $entity_type_manager = \Drupal::entityTypeManager();
+  /** @var \Drupal\node\Entity\NodeType[] $node_types */
+  $node_types = $entity_type_manager
+    ->getStorage('node_type')
+    ->loadMultiple();
+  _osu_a11y_remediation_setup_workflow($node_types);
+  _osu_a11y_add_field_to_node_type($node_types);
+}
+
+/**
+ * Sets up our Editorial Workflow.
+ *
+ * We add a new State for PRESERVE and enforce every content type to be
+ * enrolled in content moderation.
+ *
+ * @param \Drupal\node\Entity\NodeType[] $node_types
+ *
+ * @return void
+ */
+function _osu_a11y_remediation_setup_workflow(array $node_types): void {
+  $entity_type_manager = \Drupal::entityTypeManager();
+  /** @var \Drupal\content_moderation\ModerationInformation $moderation_information */
+  $moderation_information = \Drupal::service('content_moderation.moderation_information');
+
   // Add preserve state to moderation states.
-  $workflow_storage = \Drupal::entityTypeManager()
-    ->getStorage('workflow');
+  $workflow_storage = $entity_type_manager->getStorage('workflow');
   $workflows = $workflow_storage->loadByProperties(['id' => 'editorial']);
   /** @var \Drupal\workflows\Entity\Workflow $workflow */
   $workflow = $workflows ? array_values($workflows)[0] : NULL;
-  $type_plugin = $workflow->getTypePlugin();
-  $type_plugin->addState('preserve', 'Preserved');
-  // Get the configuration and set published and default revision flags.
-  $configuration = $type_plugin->getConfiguration();
-  $configuration['states']['preserve']['published'] = TRUE;
-  $configuration['states']['preserve']['default_revision'] = TRUE;
-  $type_plugin->setConfiguration($configuration);
-  $type_plugin->addTransition('preserve', 'Preserve', [
-    'published',
-    'archived',
-  ], 'preserve');
-  $workflow->save();
+  if (!is_null($workflow)) {
+    /** @var \Drupal\content_moderation\Plugin\WorkflowType\ContentModeration $type_plugin */
+    $type_plugin = $workflow->getTypePlugin();
+    $type_plugin->addState('preserve', 'Preserved');
+    foreach ($node_types as $bundle_id => $bundle) {
+      if (!$moderation_information->shouldModerateEntitiesOfBundle($bundle->getEntityType(), $bundle_id)) {
+        $type_plugin->addEntityTypeAndBundle('node', $bundle_id);
+      }
+    }
+    // Get the configuration and set published and default revision flags.
+    $configuration = $type_plugin->getConfiguration();
+    $configuration['states']['preserve']['published'] = TRUE;
+    $configuration['states']['preserve']['default_revision'] = TRUE;
+    $type_plugin->setConfiguration($configuration);
+    $type_plugin->addTransition('preserve', 'Preserve', [
+      'published',
+      'archived',
+    ], 'preserve');
+    $workflow->save();
+  }
+}
+
+/**
+ * Adds custom field to all node types.
+ *
+ * This adds our Custom Field to all node types to ensure it is present for the
+ * moderation workflow steps.
+ *
+ * @param \Drupal\node\Entity\NodeType[] $node_types
+ *
+ * @return void
+ */
+function _osu_a11y_add_field_to_node_type(array $node_types): void {
   $definition_update_manager = \Drupal::entityDefinitionUpdateManager();
   $field_definition = \Drupal::service('entity_field.manager')
     ->getFieldStorageDefinitions('node')['osu_a11y_remediation_email'];
@@ -36,21 +80,15 @@ function osu_a11y_remediation_install(): void {
     'osu_a11y_remediation',
     $field_definition,
   );
-
   $display_repository = \Drupal::service('entity_display.repository');
-  $node_types = \Drupal::entityTypeManager()
-    ->getStorage('node_type')
-    ->loadMultiple();
-
-  foreach ($node_types as $bundle => $node_type) {
-    $display_repository->getFormDisplay('node', $bundle)
+  foreach ($node_types as $bundle_id => $bundle) {
+    $display_repository->getFormDisplay('node', $bundle_id)
       ->setComponent('osu_a11y_remediation_email', [
         'type' => 'email_default',
         'weight' => 50,
       ])
       ->save();
-
-    $display_repository->getViewDisplay('node', $bundle)
+    $display_repository->getViewDisplay('node', $bundle_id)
       ->removeComponent('osu_a11y_remediation_email')
       ->save();
   }

--- a/modules/osu_a11y_remediation/osu_a11y_remediation.install
+++ b/modules/osu_a11y_remediation/osu_a11y_remediation.install
@@ -1,6 +1,11 @@
 <?php
 
 /**
+ * @file
+ * Installs the accessibility remediation email field.
+ */
+
+/**
  * Implements hook_install().
  */
 function osu_a11y_remediation_install(): void {

--- a/modules/osu_a11y_remediation/osu_a11y_remediation.install
+++ b/modules/osu_a11y_remediation/osu_a11y_remediation.install
@@ -9,6 +9,24 @@
  * Implements hook_install().
  */
 function osu_a11y_remediation_install(): void {
+  // Add preserve state to moderation states.
+  $workflow_storage = \Drupal::entityTypeManager()
+    ->getStorage('workflow');
+  $workflows = $workflow_storage->loadByProperties(['id' => 'editorial']);
+  /** @var \Drupal\workflows\Entity\Workflow $workflow */
+  $workflow = $workflows ? array_values($workflows)[0] : NULL;
+  $type_plugin = $workflow->getTypePlugin();
+  $type_plugin->addState('preserve', 'Preserved');
+  // Get the configuration and set published and default revision flags.
+  $configuration = $type_plugin->getConfiguration();
+  $configuration['states']['preserve']['published'] = TRUE;
+  $configuration['states']['preserve']['default_revision'] = TRUE;
+  $type_plugin->setConfiguration($configuration);
+  $type_plugin->addTransition('preserve', 'Preserve', [
+    'published',
+    'archived',
+  ], 'preserve');
+  $workflow->save();
   $definition_update_manager = \Drupal::entityDefinitionUpdateManager();
   $field_definition = \Drupal::service('entity_field.manager')
     ->getFieldStorageDefinitions('node')['osu_a11y_remediation_email'];
@@ -35,19 +53,5 @@ function osu_a11y_remediation_install(): void {
     $display_repository->getViewDisplay('node', $bundle)
       ->removeComponent('osu_a11y_remediation_email')
       ->save();
-  }
-}
-
-/**
- * Implements hook_uninstall().
- */
-function osu_a11y_remediation_uninstall(): void {
-  $definition_update_manager = \Drupal::entityDefinitionUpdateManager();
-  $field = $definition_update_manager->getFieldStorageDefinition(
-    'osu_a11y_remediation_email',
-    'node'
-  );
-  if ($field) {
-    $definition_update_manager->uninstallFieldStorageDefinition($field);
   }
 }

--- a/modules/osu_a11y_remediation/osu_a11y_remediation.install
+++ b/modules/osu_a11y_remediation/osu_a11y_remediation.install
@@ -25,8 +25,7 @@ function osu_a11y_remediation_install(): void {
  * enrolled in content moderation.
  *
  * @param \Drupal\node\Entity\NodeType[] $node_types
- *
- * @return void
+ *   Array of node types.
  */
 function _osu_a11y_remediation_setup_workflow(array $node_types): void {
   $entity_type_manager = \Drupal::entityTypeManager();
@@ -67,8 +66,7 @@ function _osu_a11y_remediation_setup_workflow(array $node_types): void {
  * moderation workflow steps.
  *
  * @param \Drupal\node\Entity\NodeType[] $node_types
- *
- * @return void
+ *   Array of node types.
  */
 function _osu_a11y_add_field_to_node_type(array $node_types): void {
   $definition_update_manager = \Drupal::entityDefinitionUpdateManager();

--- a/modules/osu_a11y_remediation/osu_a11y_remediation.install
+++ b/modules/osu_a11y_remediation/osu_a11y_remediation.install
@@ -1,0 +1,48 @@
+<?php
+
+/**
+ * Implements hook_install().
+ */
+function osu_a11y_remediation_install(): void {
+  $definition_update_manager = \Drupal::entityDefinitionUpdateManager();
+  $field_definition = \Drupal::service('entity_field.manager')
+    ->getFieldStorageDefinitions('node')['osu_a11y_remediation_email'];
+  $definition_update_manager->installFieldStorageDefinition(
+    'osu_a11y_remediation_email',
+    'node',
+    'osu_a11y_remediation',
+    $field_definition,
+  );
+
+  $display_repository = \Drupal::service('entity_display.repository');
+  $node_types = \Drupal::entityTypeManager()
+    ->getStorage('node_type')
+    ->loadMultiple();
+
+  foreach ($node_types as $bundle => $node_type) {
+    $display_repository->getFormDisplay('node', $bundle)
+      ->setComponent('osu_a11y_remediation_email', [
+        'type' => 'email_default',
+        'weight' => 50,
+      ])
+      ->save();
+
+    $display_repository->getViewDisplay('node', $bundle)
+      ->removeComponent('osu_a11y_remediation_email')
+      ->save();
+  }
+}
+
+/**
+ * Implements hook_uninstall().
+ */
+//function osu_a11y_remediation_uninstall(): void {
+//  $definition_update_manager = \Drupal::entityDefinitionUpdateManager();
+//  $field = $definition_update_manager->getFieldStorageDefinition(
+//    'osu_a11y_remediation_email',
+//    'node'
+//  );
+//  if ($field) {
+//    $definition_update_manager->uninstallFieldStorageDefinition($field);
+//  }
+//}

--- a/modules/osu_a11y_remediation/osu_a11y_remediation.module
+++ b/modules/osu_a11y_remediation/osu_a11y_remediation.module
@@ -5,8 +5,10 @@
  * Module file.
  */
 
+use Drupal\block\BlockInterface;
 use Drupal\Core\Entity\EntityTypeInterface;
 use Drupal\Core\Field\BaseFieldDefinition;
+use Drupal\Core\Form\FormStateInterface;
 use Drupal\Core\StringTranslation\TranslatableMarkup;
 use Drupal\node\NodeInterface;
 use Drupal\pathauto\PathautoState;
@@ -121,5 +123,57 @@ function osu_a11y_remediation_moderation_entity_validate(&$form, &$form_state): 
         ->isEmpty()) {
       $form_state->setErrorByName("new_state", t('The "Accessibility Remediation Contact" field is required when the moderation state is set to "Preserved".'));
     }
+  }
+}
+
+/**
+ * Implements hook_form_FORM_ID_alter().
+ *
+ * Set a message and disable the form for the "Preserve Contact" block.
+ */
+function osu_a11y_remediation_form_block_form_alter(&$form, FormStateInterface $form_state, $form_id) {
+  $block = $form_state->getFormObject()->getEntity();
+
+  if ($block->id() === 'madrone_views_block__preserve_contact_block_1') {
+    \Drupal::messenger()
+      ->addWarning(t('This block is managed by code and cannot be modified.'));
+    foreach (array_keys($form) as $key) {
+      if (str_starts_with($key, '#')) {
+        continue;
+      }
+      $form[$key]['#disabled'] = TRUE;
+    }
+    $form['actions']['#access'] = FALSE;
+  }
+}
+
+/**
+ * Implements hook_form_block_admin_display_form_alter().
+ *
+ * Remove the operations links (configure/delete) from the "Preserve Contact"
+ * block.
+ */
+function osu_a11y_remediation_form_block_admin_display_form_alter(array &$form, FormStateInterface $form_state): void {
+  $protected_block_id = 'madrone_views_block__preserve_contact_block_1';
+
+  if (isset($form['blocks'][$protected_block_id])) {
+    // Remove the operations links (configure/delete).
+    unset($form['blocks'][$protected_block_id]['operations']);
+    // Optionally, make the weight/region fields read-only.
+    $form['blocks'][$protected_block_id]['region-theme']['region']['#attributes']['disabled'] = TRUE;
+    $form['blocks'][$protected_block_id]['weight']['#attributes']['disabled'] = TRUE;
+  }
+}
+
+/**
+ * Implements hook_ENTITY_TYPE_predelete() for block entities.
+ *
+ * Ensures that the "Preserve Contact" block cannot be deleted.
+ */
+function osu_a11y_remediation_block_predelete(BlockInterface $block): void {
+  if ($block->id() === 'madrone_views_block__preserve_contact_block_1'
+    && !\Drupal::isConfigSyncing()
+  ) {
+    throw new \RuntimeException('This block is managed by code and cannot be deleted.');
   }
 }

--- a/modules/osu_a11y_remediation/osu_a11y_remediation.module
+++ b/modules/osu_a11y_remediation/osu_a11y_remediation.module
@@ -1,8 +1,15 @@
 <?php
 
+/**
+ * @file
+ * Module file.
+ */
+
 use Drupal\Core\Entity\EntityTypeInterface;
 use Drupal\Core\Field\BaseFieldDefinition;
 use Drupal\Core\StringTranslation\TranslatableMarkup;
+use Drupal\node\NodeInterface;
+use Drupal\pathauto\PathautoState;
 
 /**
  * Implements hook_entity_base_field_info().
@@ -10,7 +17,7 @@ use Drupal\Core\StringTranslation\TranslatableMarkup;
  * Adds a new Field for collecting the Email of whom needs to be contacted for
  * accessibility remediation.
  */
-function osu_a11y_remediation_entity_base_field_info(EntityTypeInterface $entity_type) {
+function osu_a11y_remediation_entity_base_field_info(EntityTypeInterface $entity_type): array {
   $fields = [];
   if ($entity_type->id() === 'node') {
     $fields['osu_a11y_remediation_email'] = BaseFieldDefinition::create('email')
@@ -31,4 +38,88 @@ function osu_a11y_remediation_entity_base_field_info(EntityTypeInterface $entity
       ->setRequired(FALSE);
   }
   return $fields;
+}
+
+/**
+ * Implements hook_ENTITY_TYPE_presave().
+ */
+function osu_a11y_remediation_node_presave(NodeInterface $entity) {
+  $moderation_state = $entity->get('moderation_state')->getString();
+  if ($moderation_state === 'preserve') {
+    $entity->path->pathauto = PathautoState::SKIP;
+  }
+}
+
+/**
+ * Implements hook_entity_type_alter().
+ */
+function osu_a11y_remediation_entity_type_alter(array &$entity_types): void {
+  $entity_types['node']->addConstraint('AccessibilityRemediationEmail');
+}
+
+/**
+ * Implements hook_form_FORM_ID_alter().
+ */
+function osu_a11y_remediation_form_moderation_sidebar_quick_transition_form_alter(&$form, &$form_state): void {
+  $form['#validate'][] = 'osu_a11y_remediation_moderation_sidebar_validate';
+}
+
+/**
+ * Validates the moderation sidebar form for accessibility remediation.
+ *
+ * Checks whether the "Accessibility Remediation Contact" field is provided
+ * when the moderation operation is set to "Preserve". If the field is empty,
+ * an error is added to the form state.
+ *
+ * @param array &$form
+ *   The form structure array being validated.
+ * @param \Drupal\Core\Form\FormStateInterface &$form_state
+ *   The current state of the form.
+ */
+function osu_a11y_remediation_moderation_sidebar_validate(&$form, &$form_state): void {
+  $entity = $form_state->get('entity');
+  $triggering_element = $form_state->getTriggeringElement();
+  if (isset($triggering_element['#id']) && $triggering_element['#id'] === 'preserve') {
+    if ($entity instanceof NodeInterface
+      && $entity->hasField('osu_a11y_remediation_email')
+      && $entity->get('osu_a11y_remediation_email')
+        ->isEmpty()) {
+      $form_state->setError($triggering_element, t('The "Accessibility Remediation Contact" field is required when the moderation state is set to "Preserve".<br/>
+Please use the <em>Edit content</em> button to add the field.'));
+    }
+  }
+}
+
+/**
+ * Implements hook_form_FORM_ID_alter().
+ */
+function osu_a11y_remediation_form_content_moderation_entity_moderation_form_alter(&$form, &$form_state): void {
+  $form['#validate'][] = 'osu_a11y_remediation_moderation_entity_validate';
+}
+
+/**
+ * Validates the moderation entity form for accessibility remediation.
+ *
+ * Ensures that the "Accessibility Remediation Contact" field is populated
+ * when the target moderation state is set to "Preserve". If the field is
+ * empty,
+ * an error is added to the form state under the "new_state" field.
+ *
+ * @param array &$form
+ *   The form structure array being validated.
+ * @param \Drupal\Core\Form\FormStateInterface &$form_state
+ *   The current state of the form, including user input and triggering
+ *   elements.
+ */
+function osu_a11y_remediation_moderation_entity_validate(&$form, &$form_state): void {
+  $entity = $form_state->get('entity');
+  $to_state = $form_state->getValue('new_state');
+  if ($to_state === 'preserve') {
+    if ($entity instanceof NodeInterface
+      && $entity->hasField('osu_a11y_remediation_email')
+      && $entity->get('osu_a11y_remediation_email')
+        ->isEmpty()) {
+      $form_state->setErrorByName("new_state", t('The "Accessibility Remediation Contact" field is required when the moderation state is set to "Preserved".'));
+    }
+  }
 }

--- a/modules/osu_a11y_remediation/osu_a11y_remediation.module
+++ b/modules/osu_a11y_remediation/osu_a11y_remediation.module
@@ -1,0 +1,34 @@
+<?php
+
+use Drupal\Core\Entity\EntityTypeInterface;
+use Drupal\Core\Field\BaseFieldDefinition;
+use Drupal\Core\StringTranslation\TranslatableMarkup;
+
+/**
+ * Implements hook_entity_base_field_info().
+ *
+ * Adds a new Field for collecting the Email of whom needs to be contacted for
+ * accessibility remediation.
+ */
+function osu_a11y_remediation_entity_base_field_info(EntityTypeInterface $entity_type) {
+  $fields = [];
+  if ($entity_type->id() === 'node') {
+    $fields['osu_a11y_remediation_email'] = BaseFieldDefinition::create('email')
+      ->setLabel(new TranslatableMarkup('Accessibility Remediation Contact'))
+      ->setDescription(new TranslatableMarkup('Email address to contact for accessibility remediation requests for this content.'))
+      ->setRevisionable(TRUE)
+      ->setTranslatable(TRUE)
+      ->setDisplayOptions('form', [
+        'type' => 'email_default',
+        'weight' => 10,
+        'settings' => [],
+      ])
+      ->setDisplayOptions('view', [
+        'region' => 'hidden',
+      ])
+      ->setDisplayConfigurable('form', TRUE)
+      ->setDisplayConfigurable('view', FALSE)
+      ->setRequired(FALSE);
+  }
+  return $fields;
+}

--- a/modules/osu_a11y_remediation/osu_a11y_remediation.services.yml
+++ b/modules/osu_a11y_remediation/osu_a11y_remediation.services.yml
@@ -1,0 +1,6 @@
+services:
+  osu_a11y_remediation.event_subscriber:
+    class: Drupal\osu_a11y_remediation\EventSubscriber\OsuA11yRemediationWorkflowSubscriber
+    tags:
+      - { name: event_subscriber }
+    autowire: true

--- a/modules/osu_a11y_remediation/src/EventSubscriber/OsuA11yRemediationWorkflowSubscriber.php
+++ b/modules/osu_a11y_remediation/src/EventSubscriber/OsuA11yRemediationWorkflowSubscriber.php
@@ -1,0 +1,150 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\osu_a11y_remediation\EventSubscriber;
+
+use Drupal\Component\Plugin\Exception\InvalidPluginDefinitionException;
+use Drupal\Component\Plugin\Exception\PluginNotFoundException;
+use Drupal\Core\DependencyInjection\AutowireTrait;
+use Drupal\Core\Entity\EntityMalformedException;
+use Drupal\Core\Entity\EntityTypeManagerInterface;
+use Drupal\Core\Entity\Exception\UndefinedLinkTemplateException;
+use Drupal\Core\Logger\LoggerChannelTrait;
+use Drupal\node\NodeInterface;
+use Drupal\osu_editorial_workflow\Event\ContentModerationStateChangedEvent;
+use Drupal\path_alias\AliasManagerInterface;
+use Psr\Log\LoggerInterface;
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+
+/**
+ * Subscribes to content moderation events and handles state transitions.
+ *
+ * This class listens for content moderation state change events and provides
+ * functionality to perform specific actions when a transition occurs in the
+ * content moderation workflow. It is primarily used to execute custom logic
+ * based on the defined workflows and states.
+ */
+final class OsuA11yRemediationWorkflowSubscriber implements EventSubscriberInterface {
+
+  use AutowireTrait;
+  use LoggerChannelTrait;
+
+  /**
+   * The Logger channel.
+   *
+   * @var \Psr\Log\LoggerInterface
+   */
+  private LoggerInterface $logger;
+
+  public function __construct(
+    private readonly EntityTypeManagerInterface $entityTypeManager,
+    private readonly AliasManagerInterface $aliasManager,
+  ) {
+    $this->logger = $this->getLogger('osu_editorial_workflow');
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function getSubscribedEvents(): array {
+    return [
+      'content_moderation.state_changed' => 'onContentModerationTransition',
+    ];
+  }
+
+  /**
+   * Handles content moderation state transitions.
+   *
+   * @param \Drupal\content_moderation\Event\ContentModerationStateChangedEvent|\Drupal\osu_editorial_workflow\Event\ContentModerationStateChangedEvent|\Drupal\workbench_email\EventSubscriber\ContentModerationStateChangedEvent $event
+   *   The Event listened to.
+   */
+  public function onContentModerationTransition(ContentModerationStateChangedEvent $event): void {
+    $entity = $event->getModeratedEntity();
+    $from = $event->getOriginalState();
+    $to = $event->getNewState();
+    if ($to === 'preserve') {
+      $this->archiveAlias($entity);
+      return;
+    }
+    if ($from === 'preserve') {
+      $this->restoreAlias($entity);
+    }
+  }
+
+  /**
+   * Adds archive to the alias for a given node.
+   *
+   * When setting a node to this state, we add '/archive' prefix if not already
+   * present.
+   *
+   * @param \Drupal\node\NodeInterface $node
+   *   The node for which the alias is to be set.
+   */
+  private function archiveAlias(NodeInterface $node): void {
+    try {
+      $internalPath = "/" . $node->toUrl()->getInternalPath();
+    }
+    catch (EntityMalformedException | UndefinedLinkTemplateException $e) {
+      $this->logger->error($e->getMessage());
+      return;
+    }
+    $currentAlias = $this->aliasManager->getAliasByPath($internalPath);
+    if (str_starts_with($currentAlias, '/archive/')) {
+      return;
+    }
+    $newAlias = '/archive' . $currentAlias;
+    $this->updateAlias($internalPath, $newAlias);
+  }
+
+  /**
+   * Updates the alias for a given node path with a new alias.
+   *
+   * @param string $internalPath
+   *   The internal path of the node.
+   * @param string $newAlias
+   *   The new alias to be set.
+   */
+  private function updateAlias(string $internalPath, string $newAlias): void {
+    try {
+      $pathAliasEntity = $this->entityTypeManager->getStorage('path_alias')
+        ->loadByProperties(['path' => $internalPath]);
+    }
+    catch (InvalidPluginDefinitionException | PluginNotFoundException $e) {
+      $this->logger->error($e->getMessage());
+      return;
+    }
+    if (!empty($pathAliasEntity)) {
+      $pathAliasEntity = reset($pathAliasEntity);
+      $pathAliasEntity->setAlias($newAlias);
+      $pathAliasEntity->save();
+      $this->aliasManager->cacheClear($internalPath);
+    }
+  }
+
+  /**
+   * Restores the alias for a given node.
+   *
+   * Restores the alias for a given node by removing the '/archive' prefix if
+   * present.
+   *
+   * @param \Drupal\node\NodeInterface $node
+   *   The node for which the alias is to be restored.
+   */
+  private function restoreAlias(NodeInterface $node): void {
+    try {
+      $internalPath = "/" . $node->toUrl()->getInternalPath();
+    }
+    catch (EntityMalformedException | UndefinedLinkTemplateException $e) {
+      $this->logger->error($e->getMessage());
+      return;
+    }
+    $currentAlias = $this->aliasManager->getAliasByPath($internalPath);
+    if (!str_starts_with($currentAlias, '/archive/')) {
+      return;
+    }
+    $newAlias = str_replace('/archive', '', $currentAlias);
+    $this->updateAlias($internalPath, $newAlias);
+  }
+
+}

--- a/modules/osu_a11y_remediation/src/Plugin/Validation/Constraint/AccessibilityRemediationEmailConstraint.php
+++ b/modules/osu_a11y_remediation/src/Plugin/Validation/Constraint/AccessibilityRemediationEmailConstraint.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace Drupal\osu_a11y_remediation\Plugin\Validation\Constraint;
+
+use Drupal\Core\StringTranslation\TranslatableMarkup;
+use Drupal\Core\Validation\Attribute\Constraint;
+use Symfony\Component\Validator\Constraint as SymfonyConstraint;
+
+/**
+ * Constraint for accessibility remediation email.
+ */
+#[Constraint(
+  id: 'AccessibilityRemediationEmail',
+  label: new TranslatableMarkup('Accessibility Remediation Email', [], ['context' => 'Validation']),
+  type: 'string',
+)]
+final class AccessibilityRemediationEmailConstraint extends SymfonyConstraint {
+
+  /**
+   * The default violation message.
+   *
+   * @var string
+   */
+  public string $message = 'An accessibility remediation contact email is required when content is in the Preserve—Public Record Exception state.';
+
+}

--- a/modules/osu_a11y_remediation/src/Plugin/Validation/Constraint/AccessibilityRemediationEmailConstraintValidator.php
+++ b/modules/osu_a11y_remediation/src/Plugin/Validation/Constraint/AccessibilityRemediationEmailConstraintValidator.php
@@ -18,7 +18,7 @@ use Symfony\Component\Validator\ConstraintValidator;
 final class AccessibilityRemediationEmailConstraintValidator extends ConstraintValidator {
 
   /**
-   * @{inheritdoc}
+   * {@inheritDoc}
    */
   public function validate(mixed $value, Constraint $constraint): void {
     if (empty($value)) {

--- a/modules/osu_a11y_remediation/src/Plugin/Validation/Constraint/AccessibilityRemediationEmailConstraintValidator.php
+++ b/modules/osu_a11y_remediation/src/Plugin/Validation/Constraint/AccessibilityRemediationEmailConstraintValidator.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace Drupal\osu_a11y_remediation\Plugin\Validation\Constraint;
+
+use Symfony\Component\Validator\Constraint;
+use Symfony\Component\Validator\ConstraintValidator;
+
+/**
+ * Validates the accessibility remediation email requirement for a node.
+ *
+ * Ensures that if the moderation state of the node is not set to 'preserve',
+ * the 'osu_a11y_remediation_email' field must not be empty. If this condition
+ * is not met, a constraint violation is added to the relevant field.
+ *
+ * This validator is typically used in the context of Drupal nodes to enforce
+ * certain accessibility-related rules.
+ */
+final class AccessibilityRemediationEmailConstraintValidator extends ConstraintValidator {
+
+  /**
+   * @{inheritdoc}
+   */
+  public function validate(mixed $value, Constraint $constraint): void {
+    if (empty($value)) {
+      return;
+    }
+    /** @var \Drupal\node\NodeInterface $node */
+    $node = $value;
+    assert($constraint instanceof AccessibilityRemediationEmailConstraint);
+    $moderationState = $node->get('moderation_state')->getString();
+    // Check if the moderation state is set to 'preserve'.
+    if ($moderationState === 'preserve') {
+      if ($node->get('osu_a11y_remediation_email')->isEmpty()) {
+        $this->context->buildViolation($constraint->message)
+          ->atPath('osu_a11y_remediation_email')
+          ->addViolation();
+      }
+    }
+  }
+
+}

--- a/osu_editorial_workflow.info.yml
+++ b/osu_editorial_workflow.info.yml
@@ -2,7 +2,7 @@ name: 'OSU Editorial Workflow'
 type: module
 description: 'Provides support for Editorial Workflows of content.'
 package: OSU
-version: 1.0.2
+version: 1.0.3
 core_version_requirement: ^10 || ^11
 dependencies:
   - drupal:content_moderation

--- a/osu_editorial_workflow.install
+++ b/osu_editorial_workflow.install
@@ -2,8 +2,7 @@
 
 /**
  * @file
- * Install, update, and uninstall functions for the OSU Editorial Workflow
- *   module.
+ * Install file for osu_editorial_workflow module.
  */
 
 use Drupal\user\Entity\Role;
@@ -39,7 +38,7 @@ function osu_editorial_workflow_install($is_syncing): void {
       $node_entity->setThirdPartySetting('scheduler', $scheduler_setting_key, $scheduler_setting_value);
     }
     $node_entity->save();
-    // Move the required fields to the proper spaces
+    // Move the required fields to the proper spaces.
     /** @var Drupal\Core\Entity\Entity\EntityFormDisplay $form_display */
     $form_display = Drupal::entityTypeManager()
       ->getStorage('entity_form_display')
@@ -55,7 +54,7 @@ function osu_editorial_workflow_install($is_syncing): void {
     $date_time_updates['weight'] = 60;
     $form_display->setComponent('unpublish_on', $date_time_updates);
 
-    // Set the Publish and Unpublish states for the types that use moderation
+    // Set the Publish and Unpublish states for the types that use moderation.
     $form_display->setComponent('publish_state', [
       "type" => "scheduler_moderation",
       "weight" => 55,

--- a/osu_editorial_workflow.install
+++ b/osu_editorial_workflow.install
@@ -17,7 +17,7 @@ function osu_editorial_workflow_install($is_syncing): void {
   ];
   foreach ($schedular_node_types as $node_type) {
     // Load page and story content types and enable scheduler.
-    $node_entity = Drupal::entityTypeManager()
+    $node_entity = \Drupal::entityTypeManager()
       ->getStorage('node_type')
       ->load($node_type);
     $scheduler_settings = [
@@ -39,8 +39,8 @@ function osu_editorial_workflow_install($is_syncing): void {
     }
     $node_entity->save();
     // Move the required fields to the proper spaces.
-    /** @var Drupal\Core\Entity\Entity\EntityFormDisplay $form_display */
-    $form_display = Drupal::entityTypeManager()
+    /** @var \Drupal\Core\Entity\Entity\EntityFormDisplay $form_display */
+    $form_display = \Drupal::entityTypeManager()
       ->getStorage('entity_form_display')
       ->load("node.$node_type.default");
 
@@ -96,25 +96,24 @@ function osu_editorial_workflow_install($is_syncing): void {
     'view latest version',
     'use moderation sidebar',
     'schedule publishing of nodes',
-    'schedule publishing of nodes',
     'view scheduled content',
   ];
   $administrative_permissions = [
     'administer scheduler',
     'administer workflows',
   ];
-  /** @var Drupal\user\Entity\Role $role */
+  /** @var \Drupal\user\Entity\Role $role */
   foreach ($editorial_roles as $role) {
     foreach ($editorial_permissions as $permission) {
       $role->grantPermission($permission);
-      $role->save();
     }
+    $role->save();
   }
-  /** @var Drupal\user\Entity\Role $role */
+  /** @var \Drupal\user\Entity\Role $role */
   foreach ($administrative_roles as $role) {
     foreach ($administrative_permissions as $permission) {
       $role->grantPermission($permission);
-      $role->save();
     }
+    $role->save();
   }
 }

--- a/osu_editorial_workflow.module
+++ b/osu_editorial_workflow.module
@@ -1,0 +1,96 @@
+<?php
+
+/**
+ * @file
+ * Module file.
+ */
+
+use Drupal\Component\Plugin\Exception\InvalidPluginDefinitionException;
+use Drupal\Component\Plugin\Exception\PluginNotFoundException;
+use Drupal\content_moderation\Entity\ContentModerationState;
+use Drupal\osu_editorial_workflow\Event\ContentModerationEvents;
+use Drupal\osu_editorial_workflow\Event\ContentModerationStateChangedEvent;
+
+/**
+ * Implements hook_ENTITY_TYPE_insert().
+ */
+function osu_editorial_workflow_content_moderation_state_insert(ContentModerationState $entity): void {
+  _osu_editorial_workflow_content_moderation_state_helper($entity);
+}
+
+/**
+ * Implements hook_ENTITY_TYPE_update().
+ */
+function osu_editorial_workflow_content_moderation_state_update(ContentModerationState $entity): void {
+  _osu_editorial_workflow_content_moderation_state_helper($entity);
+}
+
+/**
+ * Handles content moderation state changes for editorial workflows.
+ *
+ * This helper method processes changes in moderation states for entities
+ * and dispatches the appropriate events when relevant. It ensures support
+ * for Drupal's content moderation and custom plugins during state changes.
+ * When https://www.drupal.org/i/2873287 is merged, this method will be
+ * deprecated and replaced by the core event system.
+ *
+ * @param \Drupal\content_moderation\Entity\ContentModerationState $entity
+ *   The content moderation state entity containing the changes. It includes
+ *   moderation state information, workflow details, and associated entity
+ *   data to determine whether moderation-related actions should occur.
+ *
+ * @return void
+ *   This method does not return a value but performs internal dispatch of
+ *   moderation state change events and logs errors when encountered
+ *   (e.g., invalid plugin definitions or missing configurations).
+ */
+function _osu_editorial_workflow_content_moderation_state_helper(ContentModerationState $entity): void {
+  if (class_exists('\Drupal\content_moderation\Event\ContentModerationStateChangedEvent')) {
+    // When drupal.org/i/2873287 is merged, Core will dispatch these events.
+    return;
+  }
+  if (class_exists('Drupal\workbench_email\EventSubscriber\ContentModerationStateChangedEvent')) {
+    return;
+  }
+  $entity_type_id = $entity->get('content_entity_type_id')->getString();
+  $language_code = $entity->get('langcode')->getString();
+  try {
+    /** @var \Drupal\Core\Entity\RevisionableStorageInterface $entity_storage */
+    $entity_storage = Drupal::entityTypeManager()->getStorage($entity_type_id);
+    $moderation_state_storage = Drupal::entityTypeManager()
+      ->getStorage($entity->getEntityTypeId());
+  }
+  catch (InvalidPluginDefinitionException | PluginNotFoundException $exception) {
+    \Drupal::logger('osu_editorial_workflow')->error($exception->getMessage());
+    return;
+  }
+  /** @var \Drupal\Core\Entity\RevisionableStorageInterface $moderated_entity */
+  $moderated_entity = $entity_storage->loadRevision($entity->get('content_entity_revision_id')
+    ->getString());
+
+  /** @var \Drupal\content_moderation\ModerationInformationInterface $moderationInfo */
+  $moderationInfo = Drupal::service('content_moderation.moderation_information');
+  $isModerated = $moderationInfo->isModeratedEntity($moderated_entity);
+  if (!$isModerated) {
+    return;
+  }
+  if ($entity->getLoadedRevisionId() === NULL) {
+    $original_state = FALSE;
+  }
+  else {
+    /** @var \Drupal\content_moderation\Entity\ContentModerationState $original_content_moderation_state */
+    $original_content_moderation_state = $moderation_state_storage->loadRevision($entity->getLoadedRevisionId());
+    if (!$entity->isDefaultTranslation() && $original_content_moderation_state->hasTranslation($language_code)) {
+      $original_content_moderation_state = $original_content_moderation_state->getTranslation($language_code);
+    }
+    $original_state = $original_content_moderation_state->get('moderation_state')
+      ->getString();
+  }
+  $new_state = $entity->get('moderation_state')->getString();
+  if ($original_state === $new_state) {
+    return;
+  }
+  $workflow = $entity->get('workflow')->getString();
+  \Drupal::service('event_dispatcher')
+    ->dispatch(new ContentModerationStateChangedEvent($moderated_entity, $new_state, $original_state, $workflow), ContentModerationEvents::STATE_CHANGED);
+}

--- a/src/Event/ContentModerationEvents.php
+++ b/src/Event/ContentModerationEvents.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace Drupal\osu_editorial_workflow\Event;
+
+/**
+ * Defines events that content_moderation dispatches.
+ *
+ * @see \Drupal\osu_editorial_workflow\Event\ContentModerationStateChangedEvent
+ */
+final class ContentModerationEvents {
+
+  /**
+   * Name of the event fired when content changes state.
+   *
+   * @see \Drupal\osu_editorial_workflow\Event\ContentModerationStateChangedEvent
+   * @see \Drupal\content_moderation\Entity\ContentModerationState::realSave()
+   */
+  const STATE_CHANGED = 'content_moderation.state_changed';
+
+}

--- a/src/Event/ContentModerationStateChangedEvent.php
+++ b/src/Event/ContentModerationStateChangedEvent.php
@@ -1,0 +1,66 @@
+<?php
+
+namespace Drupal\osu_editorial_workflow\Event;
+
+use Drupal\Component\EventDispatcher\Event;
+use Drupal\Core\DependencyInjection\AutowireTrait;
+use Drupal\Core\Entity\ContentEntityInterface;
+
+/**
+ * Defines content Moderation State Changed events.
+ *
+ * @see \Drupal\content_moderation\Entity\ContentModerationState
+ * @see \Drupal\osu_editorial_workflow\Event\ContentModerationEvents
+ */
+class ContentModerationStateChangedEvent extends Event {
+
+  use AutowireTrait;
+
+  public function __construct(
+    private readonly ContentEntityInterface $moderatedEntity,
+    private readonly string $newState,
+    private readonly string $originalState,
+    private readonly string $workflow,
+  ) {}
+
+  /**
+   * Get the entity that is being moderated.
+   *
+   * @return \Drupal\Core\Entity\ContentEntityInterface
+   *   The entity that is being moderated.
+   */
+  public function getModeratedEntity(): ContentEntityInterface {
+    return $this->moderatedEntity;
+  }
+
+  /**
+   * Get the new state of the entity.
+   *
+   * @return string
+   *   The state the content has been changed to.
+   */
+  public function getNewState(): string {
+    return $this->newState;
+  }
+
+  /**
+   * Get the original state of the entity.
+   *
+   * @return string
+   *   The state the content was in.
+   */
+  public function getOriginalState(): string {
+    return $this->originalState;
+  }
+
+  /**
+   * Get the ID of the workflow.
+   *
+   * @return string
+   *   The ID of the workflow.
+   */
+  public function getWorkflow(): string {
+    return $this->workflow;
+  }
+
+}


### PR DESCRIPTION
This update/feature adds Event trigger for when content changes moderation states. Checks if other modules and/or core includes those same events to not  trigger the event again.
Creates an Event Subscriber to update the aliases of all nodes that get this action triggered.
Adds a new Field for all nodes that will capture an Email address for who to contact for the Remediation. Custom validation is added for the field to give content authors more information about why it is required.
Validation is triggered only when changing to the Preserve state.
Added new State and updated workflow for Content Moderation.